### PR TITLE
Slight tweaks to suggestion systemd service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@ Once started, the bot also accepts a few chat commands:
 
 The Séance CLI also takes an optional argument `--prefix`, which is an additional prefix to accept commands with. This is intended for cases where a single Discord user has more than one associated Séance bot, in order to be able to direct commands to a particular instance. For example, passing `--prefix b` allows you to run the chat command `b!status` to set the status for that specific instance of Séance.
 
+### systemd
 
-There is also a sample file for running the Séance Discord bot as a systemd service in [contrib](contrib/seance-discord.service). Note that for proper systemd support the Python package `sdnotify` is also required (`pip3 install sdnotify`). If you do not wish to enable this feature, you should remove the `--systemd-notify` argument from the provided service. It is suggested that you create a specific non-privileged user to run the bot under, the service config assumes this user is called "seance". Such a user can be created usually with `sudo useradd seance`.
+There is also a sample file for running the Séance Discord bot as a systemd service in [contrib](contrib/seance-discord.service). Note that for proper systemd support the Python package `sdnotify` is also required (`pip3 install sdnotify`). If you do not wish to enable this feature, you should remove the `--systemd-notify` argument from the provided service. 
+
+It is suggested that you create a specific non-privileged user to run the bot under, the service config assumes this user is called "seance". 
+
+Such a user can be created with `sudo useradd seance`. To avoid installing Séance globally, which might be ill-advised, you can create a home directory for the user, something like `sudo useradd --create-home --home-dir /srv/seance seance` will create a home directory for the user in `/srv/seance`. 
+
+To install seance and sdnotify for this user use `sudo -u seance pip3 install --user sdnotify git+https://github.com/Qyriad/Seance`.
 
 
 ## Comparison to PluralKit

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Once started, the bot also accepts a few chat commands:
 The Séance CLI also takes an optional argument `--prefix`, which is an additional prefix to accept commands with. This is intended for cases where a single Discord user has more than one associated Séance bot, in order to be able to direct commands to a particular instance. For example, passing `--prefix b` allows you to run the chat command `b!status` to set the status for that specific instance of Séance.
 
 
-There is also a sample file for running the Séance Discord bot as a systemd service in [contrib](contrib/seance-discord.service). Note that for proper systemd support the Python package `sdnotify` is also required (`pip3 install sdnotify`).
+There is also a sample file for running the Séance Discord bot as a systemd service in [contrib](contrib/seance-discord.service). Note that for proper systemd support the Python package `sdnotify` is also required (`pip3 install sdnotify`). If you do not wish to enable this feature, you should remove the `--systemd-notify` argument from the provided service. It is suggested that you create a specific non-privileged user to run the bot under, the service config assumes this user is called "seance". Such a user can be created usually with `sudo useradd seance`.
 
 
 ## Comparison to PluralKit

--- a/contrib/seance-discord.service
+++ b/contrib/seance-discord.service
@@ -5,10 +5,12 @@ After=network.target
 
 [Service]
 Type=notify
+Environment="PYTHONUNBUFFERED=1"
 Environment="SEANCE_DISCORD_TOKEN=TOKEN_HERE"
 Environment="SEANCE_DISCORD_REF_USER_ID=YOUR_USER_ID_HERE"
-ExecStart=/usr/bin/python3 -m seance.discord_bot --pattern "REGEX_HERE"
+ExecStart=/usr/bin/python3 -m seance.discord_bot --systemd-notify --pattern "REGEX_HERE"
 Restart=always
+User=seance
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Now the default configuration for environment and arguments matches what the bot expects when running under systemd.

Additionally there's now a suggestion (and assumption in the service) that you run it under an unprivileged "seance" user, which is a general best practice. (More tweaks in the future to further lock down the service are probably worth considering since it needs only network access at the moment).