### PR TITLE
Adding Reactions

### DIFF
--- a/seance/discord_bot.py
+++ b/seance/discord_bot.py
@@ -436,7 +436,7 @@ class SeanceClient(discord.Client):
                 print("Cannot use the emoji given.")
                 return
 
-        self._handle_reaction(target, payload, group_dict["action"] == '+')
+        await self._handle_reaction(target, payload, group_dict["action"] == '+')
 
     #
     # discord.py event handler overrides.

--- a/seance/discord_bot.py
+++ b/seance/discord_bot.py
@@ -34,7 +34,7 @@ DISCORD_MESSAGE_URL_PATTERN = re.compile(r'https://(?:\w+.)?discord(?:app)?.com/
 DISCORD_STATUS_PATTERN = re.compile(r'(?P<type>playing|streaming|listening to|watching|competing in)?\s*(?P<name>.+)', re.IGNORECASE | re.DOTALL)
 
 # A pattern for matching the reaction add (and remove) shortcuts in the standard client.
-DISCORD_REACTION_SHORTCUT_PATTERN = re.compile(r'(?P<action>[+-])\<a?:<name>\w{2,}:(?P<id>\d+)\>')
+DISCORD_REACTION_SHORTCUT_PATTERN = re.compile(r'(?P<action>[+-])\<a?:\w{2,}:(?P<id>\d+)\>')
 
 
 class KeepCurrentSentinel:

--- a/seance/discord_bot.py
+++ b/seance/discord_bot.py
@@ -120,6 +120,7 @@ class SeanceClient(discord.Client):
 
 
     async def _get_shortcut_target(self, message: Message):
+        """ Pulls out the referenced message, or the first non-invoking message."""
         # If the command replied to a message, then use that to get the message to edit.
         if message.reference is not None:
             target = message.reference.resolved
@@ -203,6 +204,7 @@ class SeanceClient(discord.Client):
 
 
     async def _handle_content(self, message: Message, content: str):
+        """ Interal handler for a message of content to be handled. """
         if content:
             content = content.strip()
 
@@ -227,6 +229,7 @@ class SeanceClient(discord.Client):
             print(f"Failed to delete original message: {e}.", file=sys.stderr)
     
     async def _handle_reaction(self, target: Message, payload: Union[Emoji, str], adding: bool):
+        """ Handles adding or removing a reaction to a target message. """
         if adding:
             try:
                 await target.add_reaction(payload)
@@ -411,11 +414,12 @@ class SeanceClient(discord.Client):
             print(f"Failed to delete command message: {e}.", sys.stderr)
 
     async def handle_simple_reaction(self, message: Message, content: str):
+        """ Adds or removes a simple emoji reaction to a given message """
         target = await self._get_shortcut_target(message)
         await self._handle_reaction(target, content[1], content[0] == '+') 
 
     async def handle_custom_reaction(self, message: Message, content: str):
-        """ Adds or removes the bot's reaction to a given message """
+        """ Adds or removes a custom emoji reaction to a given message """
         target = await self._get_shortcut_target(message)
         
         group_dict = DISCORD_REACTION_SHORTCUT_PATTERN.fullmatch(content).groupdict()

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ packages = find:
 install_requires =
 	discord.py @ git+https://github.com/Rapptz/discord.py
 	PythonSed @ git+https://github.com/GillesArcas/PythonSed
+	emoji @ git+https://github.com/carpedm20/emoji
 
 [options.entry_points]
 console_scripts = 


### PR DESCRIPTION
This PR adds the ability to have the proxy react to messages using a syntax that extends the discord clients built in `+:emoji:` syntax. 

To add a reaction to a message the `+:emoji:` syntax is used within a message that matches the pattern passed from proxying. 

For example `b:+:100:` will add the 💯 emoji to the first message above the invoking message, assuming the example prefix. 
(This is currently the first message in channel history that isn't the invoking message, this could potentially be refined to guarantee that it affects the message before the invoking message.)
If a reply is used then the reaction will be added to the message being replied to.

The original message will be delete once the reaction is added. 

The extension of the syntax is that `-:emoji:` can be used to remove a reaction, following the same rules for choosing a subject message. 

This supports the use of unicode emoji, custom emoji that the proxy can use and custom emoji that the proxy cannot see, but that have already been used as a reaction. 

This involves adding a new dependancy, https://github.com/carpedm20/emoji/, which has been added in line with the discord.py and PythonSed dependencies. 

Happy to refine and iterate if the current state of this contribution is not suitable. 