### PR TITLE
Improve Proxy Replies

### DIFF
--- a/seance/discord_bot.py
+++ b/seance/discord_bot.py
@@ -255,9 +255,13 @@ class SeanceClient(discord.Client):
         ref = message.reference
         if ref is not None:
             ref.fail_if_not_exists = False
+            if message.reference.resolved.author.id not in map(lambda x: x.id, message.mentions):
+                mention_flag = False
+            else:
+                mention_flag = True
 
         # Send the new message.
-        await message.channel.send(new_content, files=files, reference=ref)
+        await message.channel.send(new_content, files=files, reference=ref, mention_author=mention_flag)
 
 
     async def handle_substitute_command(self, message: Message):

--- a/seance/discord_bot.py
+++ b/seance/discord_bot.py
@@ -253,12 +253,11 @@ class SeanceClient(discord.Client):
         # Copy over any attachments, and copy the inline reply if any.
         files = [await att.to_file() for att in message.attachments]
         ref = message.reference
+        mention_flag = True
         if ref is not None:
             ref.fail_if_not_exists = False
             if message.reference.resolved.author.id not in map(lambda x: x.id, message.mentions):
                 mention_flag = False
-            else:
-                mention_flag = True
 
         # Send the new message.
         await message.channel.send(new_content, files=files, reference=ref, mention_author=mention_flag)


### PR DESCRIPTION
The proxy will now respect whether or not the invoked reply mentioned the original author and won't mention the author of the message being replied to if they weren't mentioned in the message being proxied. 

Sorry, that reads confusingly. 

Basically the proxy would always reply with mention turned on, it will now check if the invoking message did or not and follow that so now you can have the proxy reply without mentioning. 