### PR TITLE
Add the Telegram bot dependencies and script output to the setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,9 @@ install_requires =
 	discord.py @ git+https://github.com/Rapptz/discord.py
 	PythonSed @ git+https://github.com/GillesArcas/PythonSed
 	emoji @ git+https://github.com/carpedm20/emoji
+	python-telegram-bot @ git+https://github.com/python-telegram-bot/python-telegram-bot
 
 [options.entry_points]
 console_scripts = 
 	seance-discord = seance.discord_bot:main
+	seance-telegram = seance.telegram_bot:main


### PR DESCRIPTION
The Telegram bot is still part of this package and therefore should be properly functional when installed.

Currently you have to just know that it depends on `python-telegram-bot` and you cannot invoke the script as an executable. Arguably the Telegram bot should be added to the README as well, however I can see not doing this if it's not expected to be supported. It should at least be functional however.

These are the minimum changes required for the Telegram bot to work out of the box on install of the package.