### PR TITLE
Don't notify when sending proxied messages on Telegram

### DIFF
--- a/seance/telegram_bot.py
+++ b/seance/telegram_bot.py
@@ -42,7 +42,9 @@ class SeanceClient:
         for entity in entities:
             entity.offset -= entity_shift
 
-        context.bot.send_message(message.chat_id, new_content, reply_to_message_id=reply_id, entities=entities)
+        # Always disable notifications on the proxied message; if original has it disabled, this ensures it doesn't
+        # get undone by the proxied message, otherwise it prevents a double notification.
+        context.bot.send_message(message.chat_id, new_content, disable_notification=True, reply_to_message_id=reply_id, entities=entities)
 
 
     def on_message(self, update: Update, context: CallbackContext):

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,9 @@ install_requires =
 	discord.py @ git+https://github.com/Rapptz/discord.py
 	PythonSed @ git+https://github.com/GillesArcas/PythonSed
 	emoji @ git+https://github.com/carpedm20/emoji
+	python-telegram-bot @ git+https://github.com/python-telegram-bot/python-telegram-bot
 
 [options.entry_points]
 console_scripts = 
 	seance-discord = seance.discord_bot:main
+	seance-telegram = seance.telegram_bot:main


### PR DESCRIPTION
Telegram has the blissful feature of allowing a message to request to not notify when sent. 

While this is actually implemented as "Send without sound" and will actually usually send a (silent) notification on many platforms, we can use this to our advantage for proxying by always sending a proxied message without sound so that
the double send by the original and proxied message does not cause two notifications.

Furthermore, as is, this is causing the "Send without sound" feature to be useless for proxied messages, since the original message's setting is meaningless when the proxied message does not respect it.

An argument could be made that the current behavior, where "Send without sound" allows you to only send a sound notification on the proxied message itself has advantages, but considering it also doesn't allow you to use the feature properly, and has to be manually specified for every message, we view this change as a significant improvement.