### PR TITLE
Minimum viable product support for media in Telegram

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,9 @@ install_requires =
 	PythonSed @ git+https://github.com/GillesArcas/PythonSed
 	emoji @ git+https://github.com/carpedm20/emoji
 	discord-py-interactions
+	python-telegram-bot @ git+https://github.com/python-telegram-bot/python-telegram-bot
 
 [options.entry_points]
 console_scripts = 
 	seance-discord = seance.discord_bot:main
+	seance-telegram = seance.telegram_bot:main


### PR DESCRIPTION
One major downside of the Telegram bot at the moment is not supporting any proxying of messages containing media. Telegram makes messages containing media work in several ways and renames the main body to a "caption", which is exposed in the API as well, meaning that some of the code has to adjust to understand this change.

The "minimum viable product" part of this is that media groups (any message with more than one photo, video, or both), are not supported. These are a bit weirder to support and to do so correctly requires a bit more effort. In the meantime, having anything is better than nothing.