### PR TITLE
option parsing: don't consider argparse defaults over config file values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ref user id = 188344527881400991
 ref-user-id = 188344527881400991
 ```
 
-Specify the config file to use on the command-line with `--config /path/to/file` (this is the one option that cannot itself be passed in a config file 😉).
+Specify the config file to use on the command-line with `--config /path/to/file` (this is the one option that cannot itself be passed in a config file 😉). Options specified on the command line override options specified in a configuration file.
 
 An example configuration file (which is functionally identical to the `seance-discord` CLI example invocation above) can be found in [contrib/](contrib/seance.ini).
 

--- a/seance/config.py
+++ b/seance/config.py
@@ -164,13 +164,12 @@ class ConfigHandler:
             section = self.configparser[section_name]
 
 
-
         for option in self.options:
 
             option_init = option.type
 
-            cmdline_val = getattr(cmdline_args, option._argparse_name, None)
-            if cmdline_val is not None:
+            cmdline_val = getattr(cmdline_args, option._argparse_name, option.default)
+            if cmdline_val != option.default:
                 self._set_value_for(option, option_init(cmdline_val))
                 continue
 
@@ -198,9 +197,9 @@ class ConfigHandler:
                 print("No config!")
 
             # If we've reached this point, then the option hasn't been specified anywhere.
-            # Set its value to None.
+            # Set its value to the specified default value.
             # self.option_values[option.name.lower()] = None
-            self._set_value_for(option, None)
+            self._set_value_for(option, option.default)
 
 
         # Now that we've gathered every option from every source, it's time to

--- a/seance/config.py
+++ b/seance/config.py
@@ -125,7 +125,7 @@ class ConfigHandler:
             option_dict = asdict(option)
 
             # And again add the parts that aren't None.
-            for kw in ['metavar', 'default', 'help']:
+            for kw in ['metavar', 'help']:
                 if option_dict[kw] is not None:
                     add_argument_kwargs[kw] = option_dict[kw]
 
@@ -169,7 +169,7 @@ class ConfigHandler:
             option_init = option.type
 
             cmdline_val = getattr(cmdline_args, option._argparse_name, option.default)
-            if cmdline_val != option.default:
+            if cmdline_val is not None:
                 self._set_value_for(option, option_init(cmdline_val))
                 continue
 
@@ -193,8 +193,6 @@ class ConfigHandler:
                         self._set_value_for(option, option_init(config_val))
 
                     continue
-            else:
-                print("No config!")
 
             # If we've reached this point, then the option hasn't been specified anywhere.
             # Set its value to the specified default value.


### PR DESCRIPTION
This was accidentally making prefix specified in an INI config ignored over the argparse default of `''`. Oops.