### PR TITLE
discord: forward pings

### DIFF
--- a/seance/discord_bot/__init__.py
+++ b/seance/discord_bot/__init__.py
@@ -629,7 +629,7 @@ class SeanceClient(discord.Client):
                 return
 
         if self.forward_pings:
-            # If the message messages this bot, does not message the reference account,
+            # If the message mentions this bot, does not mention the reference account,
             # and the author is not this bot, forward the ping
             self_mention = next( (user for user in message.mentions if user.id == self.user.id), None)
             user_mention = next( (user for user in message.mentions if user.id == self.ref_user_id), None)

--- a/seance/discord_bot/__init__.py
+++ b/seance/discord_bot/__init__.py
@@ -567,16 +567,17 @@ class SeanceClient(discord.Client):
         print("account: {}".format(accountish))
 
     async def handle_ping(self, message):
-        # cannot do this until upgrade to 2.2
-        # silent = message.flags.silent
-
         author = message.author
         guild_name = message.guild.name
         channel_name = message.channel.name
         message_url = message.jump_url
+        silent = message.flags.silent
 
         ref_user = self.get_user(self.ref_user_id)
-        await ref_user.send(f"You have been pinged by {author.display_name} in ***{guild_name}*** \#{channel_name}: {message_url}")
+        await ref_user.send(
+            f"You have been pinged by {author.display_name} in ***{guild_name}*** \#{channel_name}: {message_url}",
+            silent=silent
+        )
 
     #
     # discord.py event handler overrides.


### PR DESCRIPTION
Currently this cannot forward the `@silent` flag, as the property to expose that in `discord.py` is not available until 2.2 (see [discord.MessageFlags.silent](https://discordpy.readthedocs.io/en/latest/api.html#discord.MessageFlags.silent)), but that should be relatively easy to add after that is upgraded.  We didn't feel confident enough in python dependency management to attempt it ourselves