### PR TITLE
Add reproxying support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ These are the available configuration options, configured as described [below](#
 - `pattern` - The regular expression pattern used to match a message to be proxied. Must contain a group named `content` which should contain the message body that will be in the proxied message.
 - `prefix` - A prefix that can be used before a `!` command (such as `!edit`) to uniquely indicate that this instance of Séance should handle the command. Unprefixed commands are always accepted, even when this is set.
 - `proxied-emoji` - A whitespace or comma separated list of unicode emoji (`🤝`) and Discord custom emoji ID numbers that will *always* be reproxied by Séance when used as a reaction by the reference user. The reference user will *not* be able to react with this emoji themselves, it will always be removed.
+- `valid-reproxy-targets` — A list of Discord user IDs that are considered acceptable targets for the `!reproxy` command. **Warning**: It is *extremely* important that you double check this list, as Séance (unlike PluralKit or similar) has no way of knowing these IDs are your own Séance bots or even knowing if they're Séance instances at all. Be very careful with this. The reference user is always included regardless of what's configured here.
 
 - **TODO: DM Mode configuration**
 
@@ -54,6 +55,7 @@ Once started, the bot also accepts a few chat commands:
 - `!status [playing | streaming | listening to | watching | competing in] <status>` — sets the bot's status ("playing" is the default if not specified)
 - `!presence [invisible|dnd|idle|online|sync]` — sets the bot's presence to the specified value, or sets it to synchronize it to the reference user
 - `!nick [nickname]` — sets the bot's nickname
+- `<prefix>!reproxy` — reproxies a message to be from this bot, if a prefix is configured, it **must** be used to ensure collision safety against other instances of Séance. This is valid in conjunction with the `valid-reproxy-targets` option, which specifies valid user IDs to target. The reference user is always included on this list.
 
 The Séance CLI also takes an optional argument `--prefix`, which is an additional prefix to accept commands with. This is intended for cases where a single Discord user has more than one associated Séance bot, in order to be able to direct commands to a particular instance. For example, passing `--prefix b` allows you to run the chat command `b!status` to set the status for that specific instance of Séance.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ $ seance-discord --token ODDFOFXUpgf7yEntul5ockCA.OFk6Ph.lmsA54bT0Fux1IpsYvey5Xu
 
 Note that the Discord bot also requires the Presence and Server Members Privileged Gateway Intents, which can be enabled in the "Bot" settings of the Discord application page.
 
+### Options
+
+These are the available configuration options, configured as described [below](#config-file).
+
+#### Discord
+- `token` - The Discord bot token used to authenticate, **important**: this must be kept secret as it allows anyone to control your bot account.
+- `ref-user-id` - The reference user's Discord ID. This is the user account allowed to proxy messages and execute Séance commands.
+- `pattern` - The regular expression pattern used to match a message to be proxied. Must contain a group named `content` which should contain the message body that will be in the proxied message.
+- `prefix` - A prefix that can be used before a `!` command (such as `!edit`) to uniquely indicate that this instance of Séance should handle the command. Unprefixed commands are always accepted, even when this is set.
+- `proxied-emoji` - A whitespace or comma separated list of unicode emoji (`🤝`) and Discord custom emoji ID numbers that will *always* be reproxied by Séance when used as a reaction by the reference user. The reference user will *not* be able to react with this emoji themselves, it will always be removed.
+
+- **TODO: DM Mode configuration**
+
+
+#### Telegram
+**TODO**
+
 ### Config File
 
 Anything that can be passed as a command-line option can also be specified an INI config file. Options for the Discord bot are placed under a `[Discord]` section, with the name of the INI key being the same as the command-line option without the leading `--`. Words can be separated by dashes, underscores, or spaces. For example, `--ref-user-id 188344527881400991` can be any of the following:
@@ -80,6 +97,7 @@ Pros of Séance over PluralKit on Discord:
 - No webhooks; real Discord account
   - Role colors in name
   - Real replies
+- Easily proxy emoji reactions
 
 Cons of Séance over PluralKit on Discord:
 - Requires self-hosting

--- a/seance/discord_bot/__init__.py
+++ b/seance/discord_bot/__init__.py
@@ -53,11 +53,10 @@ class SeanceClient(discord.Client):
 
     def __init__(self, ref_user_id, pattern, command_prefix, *args, dm_guild_id=None, dm_manager_options=None,
         sdnotify=False, default_status=False, default_presence=False, forward_pings=None, proxied_emoji=set(),
-        **kwargs
+        valid_reproxy_targets=set(), **kwargs
     ):
 
         self.ref_user_id = ref_user_id
-        self.proxied_emoji = proxied_emoji
 
         # If we weren't given an already compiled re.Pattern, compile it now.
         if not isinstance(pattern, re.Pattern):
@@ -71,6 +70,11 @@ class SeanceClient(discord.Client):
         self.default_status = default_status
         self.default_presence = default_presence
         self.forward_pings = forward_pings
+        self.proxied_emoji = proxied_emoji
+        self.valid_reproxy_targets = valid_reproxy_targets
+
+        # We always support reproxying our reference user.
+        self.valid_reproxy_targets.add(self.ref_user_id)
 
         super().__init__(*args, enable_debug_events=True, **kwargs)
 
@@ -92,6 +96,7 @@ class SeanceClient(discord.Client):
             '!status': self.handle_status_command,
             '!presence': self.handle_presence_command,
             '!nick': self.handle_nickname_command,
+            '!reproxy': self.handle_reproxy_command,
         }
 
         self.shortcut_handlers = {
@@ -176,7 +181,7 @@ class SeanceClient(discord.Client):
         return target
 
 
-    async def _get_target_message_and_args(self, message: Message, command_terminator=' '):
+    async def _get_target_message_and_args(self, message: Message, command_terminator=' ', use_history=True):
         """ Parse out a target message and remaining arguments from a message.
 
         This is useful for commands like !edit that take a message somehow, but messages can be passed in 3 forms:
@@ -186,6 +191,7 @@ class SeanceClient(discord.Client):
                 arguments are everything after "word 1".
             3. A link, in which case the channel and message ID are both parsed from that command word, and the
                 rest of the arguments are everything after "word 1" again.
+            4. If all else fails we will search the last five messages for the most recent proxied message. This is controlled by the `use_history` parameter and defaults to `True`.
 
             This method is a disaster.
         """
@@ -232,6 +238,9 @@ class SeanceClient(discord.Client):
                     return target, message.content[(end + 1):]
 
                 except (AttributeError, IndexError, HTTPException) as e:
+
+                    if not use_history:
+                        return None, None
 
                     # Okay. No link. No ID. No reply. Just find the last proxied message within 5 messages.
                     prev_messages = message.channel.history(limit=5)
@@ -541,6 +550,63 @@ class SeanceClient(discord.Client):
         except HTTPException as e:
             print(f"Failed to delete messsage: {e}.", file=sys.stderr)
 
+    async def handle_reproxy_command(self, message: Message):
+        """ <prefix>!reproxy -- reproxies a specified message. """
+
+        # We don't care about any arguments, but a reproxy *must* be prefixed
+        # if we've at all defined a prefix, this is a heuristic of sorts to
+        # indicate that there are other Séance instances to worry about.
+        if not message.content.startswith(self.command_prefix):
+            # An empty prefix (`''`) will match against anything so this will still allow
+            # unprefixed reproxying when a prefix isn't set.
+            print("Reproxy requested but command was unprefixed which is disallowed for safety.", file=sys.stderr)
+            return
+
+        # We require a targeted message to know what to reproxy.
+        # We have to manually handle history based targeting because we need custom logic to skip the
+        # command message and still include the reference user's previous messages.
+        target, _ = await self._get_target_message_and_args(message, use_history = False)
+
+        # Custom history based targeting logic.
+        if target is None:
+            # Try to look in the last 6 messages, skipping our command message.
+            prev_messages = message.channel.history(limit=6)
+            async for msg in prev_messages:
+                if msg.id == message.id:
+                    # Skip our command message.
+                    continue
+                if msg.author.id in self.valid_reproxy_targets:
+                    target = msg
+                    break
+
+        if target is None:
+            print("Reproxy requested but no valid proxied message found within 5 messages!", file=sys.stderr)
+            return
+
+        # We must check that the returned result was *actually* a message by an author we're allowed to reproxy.
+        if target.author.id not in self.valid_reproxy_targets:
+            print("Reproxy requested but specified message was not authored by a reproxy allowed user!",
+                  file = sys.stderr)
+            return
+
+        # Now we get down to actually reproxying
+        try:
+            await self.proxy(target, target.content)
+        except HTTPException as e:
+            print(f"Failed to proxy message during reproxy: {e}\nNot deleting original message.", file=sys.stderr)
+            return
+
+        try:
+            await target.delete()
+        except HTTPException as e:
+            print(f"Failed to delete target message: {e}\nNot deleting command message.", file=sys.stderr)
+            return
+
+        try:
+            await message.delete()
+        except HTTPException as e:
+            print(f"Failed to delete command message: {e}.", file=sys.stderr)
+
 
     async def handle_simple_reaction(self, message: Message, content: str):
         """ Adds or removes a simple emoji reaction to a given message """
@@ -782,10 +848,10 @@ class SeanceClient(discord.Client):
             print('An error occurred while trying to reproxy a force proxied emoji', file=sys.stdout)
 
 
-def _split_proxied_emoji(s: str) -> set[str]:
-    """Split our list of proxied emoji and cleanup the result to produce a set of emoji IDs and Unicode emoji.."""
+def _split_option(s: str) -> set[str]:
+    """Split a list of whitespace or comma separated values provided in an option."""
 
-    emoji = set()
+    values = set()
 
     # Split by non-alphanum and commas.
     for item in re.split(r'\s+|,', s):
@@ -794,9 +860,9 @@ def _split_proxied_emoji(s: str) -> set[str]:
             continue
 
         # Append to our set of items.
-        emoji.add(item)
+        values.add(item)
 
-    return emoji
+    return values
 
 def main():
 
@@ -830,6 +896,9 @@ def main():
         ),
         ConfigOption(name='proxied emoji', required=False, default='',
             help="Comma or whitespace separated list of emoji or emoji IDs to always proxy when used as a reaction by the reference user."
+        ),
+        ConfigOption(name='valid reproxy targets', required=False, default='',
+            help="Comma or whitespace separated list of user IDs. Only messages authored by an entry in this list will be allowed as targets of !reproxy."
         ),
     ]
 
@@ -888,7 +957,8 @@ def main():
         default_presence = options.default_presence,
         forward_pings=options.forward_pings,
         intents=intents,
-        proxied_emoji=_split_proxied_emoji(options.proxied_emoji),
+        proxied_emoji=_split_option(options.proxied_emoji),
+        valid_reproxy_targets={int(i) for i in _split_option(options.valid_reproxy_targets)},
     )
     print("Starting Séance Discord bot.")
     client.run(options.token)

--- a/seance/discord_bot/__init__.py
+++ b/seance/discord_bot/__init__.py
@@ -330,7 +330,10 @@ class SeanceClient(discord.Client):
         mention_flag = True
         if ref is not None:
             ref.fail_if_not_exists = False
-            if message.reference.resolved.author.id not in map(lambda x: x.id, message.mentions):
+            # Sometimes the API might not actually pass the resolved message, we refetch it anyway.
+            if ref.resolved is None:
+                ref.resolved = await message.channel.fetch_message(message.reference.message_id)
+            if ref.resolved.author.id not in map(lambda x: x.id, message.mentions):
                 mention_flag = False
 
         # Send the new message.

--- a/seance/discord_bot/__init__.py
+++ b/seance/discord_bot/__init__.py
@@ -238,6 +238,8 @@ class SeanceClient(discord.Client):
                     async for msg in prev_messages:
                         if msg.author.id == self.user.id:
                             return msg, message.content[(message.content.find(command_terminator) + 1):]
+        # If nothing worked, return None, None.
+        return None, None
 
 
     async def _handle_content(self, message: Message, content: str):
@@ -371,7 +373,7 @@ class SeanceClient(discord.Client):
         try:
             await target.edit(content=new_content)
         except HTTPException as e:
-            print(f"Failed to edit message: {e}.\nNot deleting original message.")
+            print(f"Failed to edit message: {e}.\nNot deleting command message.")
             return
 
         # Delete the message that executed the command.
@@ -395,13 +397,13 @@ class SeanceClient(discord.Client):
         try:
             await target.edit(content=new_content)
         except HTTPException as e:
-            print(f"Failed to edit message: {e}\nNot deleting original message.", file=sys.stderr)
+            print(f"Failed to edit message: {e}\nNot deleting command message.", file=sys.stderr)
             return
 
         try:
             await message.delete()
         except HTTPException as e:
-            print(f"Failed to delete original message: {e}.", file=sys.stderr)
+            print(f"Failed to delete command message: {e}.", file=sys.stderr)
 
 
     async def handle_delete_command(self, message: Message):
@@ -418,13 +420,13 @@ class SeanceClient(discord.Client):
         try:
             await target.delete()
         except HTTPException as e:
-            print(f"Failed to delete message: {e}\nNot deleting original message.", file=sys.stderr)
+            print(f"Failed to delete targeted message: {e}\nNot deleting command message.", file=sys.stderr)
             return
 
         try:
             await message.delete()
         except HTTPException as e:
-            print(f"Failed to delete original message: {e}.", file=sys.stderr)
+            print(f"Failed to delete command message: {e}.", file=sys.stderr)
 
 
     async def handle_presence_command(self, message: Message):
@@ -826,8 +828,8 @@ def main():
         ConfigOption(name='Forward pings', required=False, default=False, type=bool,
             help="Whether to message the proxied user upon the bot getting pinged",
         ),
-        ConfigOption(name='proxied emoji', required=False, default=set(),
-            help="Comma separated list of emoji or emoji IDs to always proxy when used as a reaction by the reference user."
+        ConfigOption(name='proxied emoji', required=False, default='',
+            help="Comma or whitespace separated list of emoji or emoji IDs to always proxy when used as a reaction by the reference user."
         ),
     ]
 


### PR DESCRIPTION
This adds a new `!reproxy` command along with a `valid-reproxy-targets` option to control whom it may target.

The reference user is always allowed as a target and the command must be prefixed if a command prefix is specified in order to avoid multiple Séance instances competing for a reproxy.