### PR TITLE
Update PythonSed to fix errors on newer Python versions

### DIFF
--- a/nix/python-sed.nix
+++ b/nix/python-sed.nix
@@ -7,21 +7,28 @@
     buildPythonPackage
     setuptools
     wheel
+    hatchling
   ;
 in buildPythonPackage {
-  pname = "sed";
-  version = "1.0";
+  pname = "pythonsed";
+  version = "v2.1post0";
 
   src = fetchFromGitHub {
-    owner = "GillesArcas";
+    owner = "fschaeck";
     repo = "PythonSed";
-    rev = "342534107e8168fe2889dcd2c9c8126546233c2f";
-    hash = "sha256-RdjR+sWjymmB7xCxiPe1xs3x7NXUyXlFM8hVllOwqFE=";
+    rev = "d091c35b202959d4c899254b3f34b48ea4c283be";
+    hash = "sha256-s3Oq7ox6ol/CEJmKhZgyECapRPA0Se5vBxd0bPlCPDk=";
   };
+
+  format = "pyproject";
 
   nativeBuildInputs = [
     setuptools
     wheel
+  ];
+
+  buildInputs = [
+    hatchling
   ];
 
   meta = {

--- a/seance/discord_bot/__init__.py
+++ b/seance/discord_bot/__init__.py
@@ -350,22 +350,24 @@ class SeanceClient(discord.Client):
             print("Substitution requested but no proxied message was found within 5 messages!")
             return
 
-        sed = Sed()
-
         # Basic regular expressions suck.
-        sed.regexp_extended = True
+        sed = Sed(regexp_extended = True)
 
         # Don't include the command prefix.
         start = message.content.find('!') + 1
         try:
             sed.load_string(message.content[start:])
+            # Try to compile the script to see if it's well formed.
+            sed.script.compile()
         except PythonSed.sed.SedException:
             # If it failed, try again adding a trailing slash.
+            sed = Sed(regexp_extended = True)
             sed.load_string(f"{message.content[start:]}/")
+            # Have to try to compile it here otherwise we could try to edit without actually seeing a failure.
+            sed.script.compile()
 
         # PythonSed accepts a file-like object, not a string, so we have to wrap the it in a StringIO object.
         new_content = sed.apply(StringIO(target.content), output=None)
-
 
         # Sed returns a list of lines, but we need a single string, so...
         new_content = '\n'.join(new_content)


### PR DESCRIPTION
This bumps us to the modernized PythonSed version (https://github.com/fschaeck/PythonSed) which is more robustly implemented and does not use part of `re`'s internal interface (which broke it on NixOS 24.11's default Python).

In making this change we also have to tweak how PythonSed gets used as it is less flexible about exceptions during loading and does not validate the commands given until they're compiled which is triggered during apply, too late for us to catch it and try modifying the pattern to fix a missing trailing delimiter.

In the future a patch to allow missing trailing delimiters inside PythonSed itself would probably be worthwhile as that's the most accessible way to support other delimiters than `/` 